### PR TITLE
Removed -usgs suffixing advice

### DIFF
--- a/software/README.md
+++ b/software/README.md
@@ -5,10 +5,7 @@ Getting Started with Software Development
 Join the USGS Organization on GitHub
 ------------------------------------
 
-If you do not yet have an account, you can [create a free account][1]. All
-GitHub accounts are personal, but if you have no preference, it is recommended
-your account username be your USGS username followed by a hyphen, followed by
-lowercase "usgs". For example: "jdoe-usgs".
+If you do not yet have an account, you can [create a free account][1].
 
 [Associate your official USGS email address with your GitHub account][2]. This
 can be done using the newly-created account (above) if you did not previously


### PR DESCRIPTION
I recommend removing the rule because it encourages people to violate the GitHub terms of service.

"you may not have more than one free account"
https://help.github.com/articles/github-terms-of-service/#b-account-terms

A lot of people already have GitHub accounts. If they get the impression that they can't use their existing account for USGS work, then they will create a second USGS-specific free account.

Alternatively, if someone creates their first GitHub account while working for the USGS, they will probably want to use GitHub after they leave the USGS. After they leave the USGS we would 
want them to cease using a -usgs account for non-USGS activities, so they would have to create a non-USGS free account.